### PR TITLE
Increase service testing

### DIFF
--- a/tests/unit/test_client_store.py
+++ b/tests/unit/test_client_store.py
@@ -1,0 +1,84 @@
+"""Unit tests for the :mod:`client_store` service."""
+
+import time
+from datetime import UTC, datetime
+
+import pytest
+
+from meraki_dashboard_exporter.core.api_models import NetworkClient
+from meraki_dashboard_exporter.core.config import Settings
+from meraki_dashboard_exporter.services.client_store import ClientStore
+
+
+@pytest.fixture
+def store(monkeypatch):
+    """Create a :class:`ClientStore` instance for testing."""
+
+    monkeypatch.setenv("MERAKI_EXPORTER_MERAKI__API_KEY", "a" * 40)
+    settings = Settings()
+    return ClientStore(settings)
+
+
+def _make_client(client_id: str, ip: str, status: str = "Online") -> NetworkClient:
+    """Create a minimal :class:`NetworkClient` model."""
+    now = datetime.now(UTC)
+    return NetworkClient(
+        id=client_id,
+        mac="aa:bb:cc:dd:ee:" + client_id[-2:],
+        ip=ip,
+        firstSeen=now,
+        lastSeen=now,
+        status=status,
+    )
+
+
+def test_update_and_retrieve_client(store):
+    """Verify clients can be added, updated and retrieved."""
+
+    c1 = _make_client("c1", "10.0.0.1")
+    store.update_clients(
+        "N1", [c1], network_name="Net1", org_id="O1", hostnames={"10.0.0.1": "host1"}
+    )
+
+    retrieved = store.get_client("N1", "c1")
+    assert retrieved is not None
+    assert retrieved.hostname == "host1"
+    assert store.get_client_by_mac(c1.mac) == retrieved
+    assert store.get_clients_by_ip("10.0.0.1") == [retrieved]
+    assert store.get_network_clients("N1") == [retrieved]
+    assert store.get_all_clients() == [retrieved]
+    assert store.get_network_names() == {"N1": "Net1"}
+    assert store.is_network_stale("N1") is False
+
+    # update existing client
+    updated = _make_client("c1", "10.0.0.2", status="Offline")
+    store.update_clients("N1", [updated])
+    retrieved2 = store.get_client("N1", "c1")
+    assert retrieved2.ip == "10.0.0.2"
+    assert retrieved2.status == "Offline"
+
+
+def test_is_network_stale_and_cleanup(store):
+    """Ensure stale networks are detected and removed."""
+
+    c1 = _make_client("c1", "10.0.0.1")
+    store.update_clients("N1", [c1])
+    # Force last update to be old
+    store._last_update["N1"] = time.time() - store.cache_ttl - 1
+    assert store.is_network_stale("N1") is True
+    removed = store.cleanup_stale_networks()
+    assert removed == 1
+    assert store.get_network_clients("N1") == []
+
+
+def test_get_statistics(store):
+    """Check that statistics reporting aggregates correctly."""
+
+    c1 = _make_client("c1", "10.0.0.1")
+    c2 = _make_client("c2", "10.0.0.2", status="Offline")
+    store.update_clients("N1", [c1, c2])
+    stats = store.get_statistics()
+    assert stats["total_networks"] == 1
+    assert stats["total_clients"] == 2
+    assert stats["online_clients"] == 1
+    assert stats["offline_clients"] == 1

--- a/tests/unit/test_client_store.py
+++ b/tests/unit/test_client_store.py
@@ -1,5 +1,7 @@
 """Unit tests for the :mod:`client_store` service."""
 
+# ruff: noqa: S101
+
 import time
 from datetime import UTC, datetime
 

--- a/tests/unit/test_dns_resolver.py
+++ b/tests/unit/test_dns_resolver.py
@@ -2,9 +2,7 @@
 
 # ruff: noqa: S101
 
-import inspect
 import warnings
-from typing import Any
 
 import pytest
 
@@ -75,14 +73,15 @@ async def test_resolve_multiple_uses_resolver(monkeypatch, resolver):
 
     monkeypatch.setattr(resolver, "resolve_hostname", fake_resolve)
 
-    # Support both the original and updated resolver signatures
-    arg: list[Any] = ["1.1.1.1", "2.2.2.2"]
-    if "clients" in list(inspect.signature(resolver.resolve_multiple).parameters):
-        arg = [("c1", "1.1.1.1", None), ("c2", "2.2.2.2", None)]
-
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=RuntimeWarning)
-        result = await resolver.resolve_multiple(arg)
+        try:
+            result = await resolver.resolve_multiple(["1.1.1.1", "2.2.2.2"])
+        except (TypeError, ValueError):
+            result = await resolver.resolve_multiple([
+                ("c1", "1.1.1.1", None),
+                ("c2", "2.2.2.2", None),
+            ])
 
     assert calls == ["1.1.1.1", "2.2.2.2"]
     assert result == {"1.1.1.1": "1", "2.2.2.2": "2"}

--- a/tests/unit/test_exemplars.py
+++ b/tests/unit/test_exemplars.py
@@ -1,5 +1,7 @@
 """Tests for exemplar utilities."""
 
+# ruff: noqa: S101
+
 from opentelemetry import trace
 from prometheus_client import Gauge
 

--- a/tests/unit/test_exemplars.py
+++ b/tests/unit/test_exemplars.py
@@ -1,0 +1,85 @@
+"""Tests for exemplar utilities."""
+
+from opentelemetry import trace
+from prometheus_client import Gauge
+
+from meraki_dashboard_exporter.core.exemplars import (
+    ExemplarCollector,
+    ExemplarManager,
+)
+
+
+def test_add_exemplar_to_metric_with_active_span(monkeypatch):
+    """Value is recorded when a span is active."""
+    metric = Gauge("test_exemplar_metric", "desc")
+    em = ExemplarManager()
+
+    class DummySpan:
+        def __init__(self) -> None:
+            self.ended = False
+            self._context = type("ctx", (), {"trace_id": 1, "span_id": 2, "is_valid": True})
+
+        def is_recording(self) -> bool:
+            return True
+
+        def get_span_context(self):
+            return self._context
+
+        def end(self) -> None:
+            self.ended = True
+
+    class DummyTracer:
+        def start_span(self, *args, **kwargs):
+            return DummySpan()
+
+    dummy_span = DummySpan()
+
+    def fake_get_current_span() -> DummySpan:
+        return dummy_span
+
+    def fake_get_tracer(name: str) -> DummyTracer:
+        return DummyTracer()
+
+    monkeypatch.setattr(trace, "get_current_span", fake_get_current_span)
+    monkeypatch.setattr(trace, "get_tracer", fake_get_tracer)
+
+    em.add_exemplar_to_metric(metric, value=5)
+    assert metric._value.get() == 5
+
+
+def test_exemplar_collector_trace_id_management(monkeypatch):
+    """Collector stores and trims trace IDs."""
+    em = ExemplarManager()
+    coll = ExemplarCollector(em)
+
+    class DummySpan:
+        def __init__(self) -> None:
+            self.ended = False
+            self._context = type("ctx", (), {"trace_id": 1, "span_id": 2, "is_valid": True})
+
+        def is_recording(self) -> bool:
+            return True
+
+        def get_span_context(self):
+            return self._context
+
+        def end(self) -> None:
+            self.ended = True
+
+    class DummyTracer:
+        def start_span(self, *args, **kwargs):
+            return DummySpan()
+
+    monkeypatch.setattr(trace, "get_tracer", lambda name: DummyTracer())
+
+    span = coll.start_collection("devices")
+    trace_id = coll.get_recent_trace_ids()[0]
+    coll.end_collection(span)
+    assert trace_id in coll.get_recent_trace_ids()
+
+    # Add many spans
+    for i in range(15):
+        s = coll.start_collection(f"c{i}")
+        coll.end_collection(s)
+    coll.clear_old_trace_ids(keep_last=5)
+    assert len(coll.get_recent_trace_ids(100)) <= 5

--- a/tests/unit/test_logging_decorators.py
+++ b/tests/unit/test_logging_decorators.py
@@ -1,5 +1,7 @@
 """Tests for logging decorator helper functions."""
 
+# ruff: noqa: S101
+
 import meraki_dashboard_exporter.core.logging_decorators as ld
 
 

--- a/tests/unit/test_logging_decorators.py
+++ b/tests/unit/test_logging_decorators.py
@@ -1,0 +1,18 @@
+"""Tests for logging decorator helper functions."""
+
+import meraki_dashboard_exporter.core.logging_decorators as ld
+
+
+def test_extract_context_from_args_and_kwargs():
+    """Should prefer kwargs but fallback to first arg for org_id."""
+    ctx = ld._extract_context(("org_123",), {"network_id": "n1", "name": "Test"})
+    assert ctx == {"network_id": "n1", "name": "Test", "org_id": "org_123"}
+
+
+def test_get_result_info_various_types():
+    """Ensure result info summarises data correctly."""
+    assert ld._get_result_info(None) == {"result": "none"}
+    assert ld._get_result_info([1, 2]) == {"result_count": 2, "result_type": "list"}
+    assert ld._get_result_info({"items": [1]}) == {"result_type": "dict", "result_count": 1}
+    assert ld._get_result_info({"a": 1}) == {"result_type": "dict"}
+    assert ld._get_result_info("hi") == {"result_type": "str"}

--- a/tests/unit/test_logging_helpers.py
+++ b/tests/unit/test_logging_helpers.py
@@ -1,5 +1,7 @@
 """Tests for logging helpers functions."""
 
+# ruff: noqa: S101
+
 import structlog
 
 from meraki_dashboard_exporter.core import logging_helpers as lh

--- a/tests/unit/test_logging_helpers.py
+++ b/tests/unit/test_logging_helpers.py
@@ -1,0 +1,50 @@
+"""Tests for logging helpers functions."""
+
+import structlog
+
+from meraki_dashboard_exporter.core import logging_helpers as lh
+
+
+def test_format_bytes_and_duration():
+    """Verify human-readable formatting utilities."""
+    assert lh.format_bytes(512) == "512.0 B"
+    assert lh.format_bytes(1024) == "1.0 KB"
+    assert lh.format_bytes(1536) == "1.5 KB"
+
+    assert lh.format_duration(0.5) == "500ms"
+    assert lh.format_duration(10) == "10.0s"
+    assert lh.format_duration(90) == "1m 30s"
+    assert lh.format_duration(3600 + 120) == "1h 2m"
+
+
+def test_log_context_binds_and_unbinds(monkeypatch):
+    """Ensure LogContext binds and unbinds values."""
+    calls: list[tuple[str, object]] = []
+
+    def fake_bind(**kwargs):
+        calls.append(("bind", kwargs))
+        return object()
+
+    def fake_unbind(*args):
+        calls.append(("unbind", args))
+
+    monkeypatch.setattr(structlog.contextvars, "bind_contextvars", fake_bind)
+    monkeypatch.setattr(structlog.contextvars, "unbind_contextvars", fake_unbind)
+
+    with lh.LogContext(example="value"):
+        pass
+
+    assert calls == [("bind", {"example": "value"}), ("unbind", ("example",))]
+
+
+def test_log_with_context_passes_values(monkeypatch):
+    """log_with_context should forward context to logger."""
+    recorded = {}
+
+    def fake_log(message, **kwargs):
+        recorded["msg"] = message
+        recorded.update(kwargs)
+
+    monkeypatch.setattr(lh.logger, "info", fake_log)
+    lh.log_with_context("info", "message", collector="c1", extra="x")
+    assert recorded == {"msg": "message", "collector": "c1", "extra": "x"}

--- a/tests/unit/test_span_metrics.py
+++ b/tests/unit/test_span_metrics.py
@@ -1,5 +1,7 @@
 """Tests for span metrics generation from OpenTelemetry spans."""
 
+# ruff: noqa: S101
+
 from __future__ import annotations
 
 import time

--- a/tests/unit/test_span_metrics.py
+++ b/tests/unit/test_span_metrics.py
@@ -1,0 +1,142 @@
+"""Tests for span metrics generation from OpenTelemetry spans."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from opentelemetry.trace import StatusCode
+from prometheus_client import CollectorRegistry
+
+from meraki_dashboard_exporter.core.span_metrics import (
+    SpanMetricsProcessor,
+    setup_span_metrics,
+)
+from tests.helpers.metrics import MetricAssertions
+
+
+class _DummySpan:
+    """Simple span object for testing on_start."""
+
+    def __init__(self) -> None:
+        self.attributes: dict[str, Any] = {}
+
+    def set_attribute(self, key: str, value: Any) -> None:
+        self.attributes[key] = value
+
+
+class _DummyReadableSpan(_DummySpan):
+    """Readable span for testing on_end."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        attributes: dict[str, Any] | None = None,
+        status_code: StatusCode = StatusCode.OK,
+        events: list[Any] | None = None,
+        duration: float = 0.1,
+    ) -> None:
+        super().__init__()
+        self.name = name
+        if attributes:
+            self.attributes.update(attributes)
+        self.status = type("Status", (), {"status_code": status_code})()
+        self.events = events or []
+        self.start_time = time.time_ns()
+        self.end_time = self.start_time + int(duration * 1e9)
+
+
+def make_exception_event(exc_type: str) -> Any:
+    """Create a span event representing an exception."""
+
+    return type(
+        "Event",
+        (),
+        {"name": "exception", "attributes": {"exception.type": exc_type}},
+    )()
+
+
+def test_on_start_sets_start_time() -> None:
+    """Verify ``on_start`` records the start timestamp."""
+
+    registry = CollectorRegistry()
+    processor = SpanMetricsProcessor(registry)
+    span = _DummySpan()
+    processor.on_start(span)  # type: ignore[arg-type]
+    assert "span.start_time" in span.attributes
+
+
+def test_on_end_records_metrics() -> None:
+    """Ensure ``on_end`` generates expected metrics."""
+
+    registry = CollectorRegistry()
+    processor = SpanMetricsProcessor(registry)
+    metrics = MetricAssertions(registry)
+
+    # Successful span
+    ok_span = _DummyReadableSpan(
+        "op",
+        attributes={"collector.name": "C", "api.endpoint": "https://api/x"},
+    )
+    processor.on_end(ok_span)  # type: ignore[arg-type]
+
+    # Error span with exception event
+    err_span = _DummyReadableSpan(
+        "op",
+        attributes={"collector.name": "C", "api.endpoint": "https://api/x"},
+        status_code=StatusCode.ERROR,
+        events=[make_exception_event("ValueError")],
+    )
+    processor.on_end(err_span)  # type: ignore[arg-type]
+
+    metrics.assert_counter_value(
+        "meraki_span_requests",
+        1,
+        operation="op",
+        collector="C",
+        endpoint="/x",
+        status="success",
+    )
+    metrics.assert_counter_value(
+        "meraki_span_requests",
+        1,
+        operation="op",
+        collector="C",
+        endpoint="/x",
+        status="error",
+    )
+    metrics.assert_counter_value(
+        "meraki_span_errors",
+        1,
+        operation="op",
+        collector="C",
+        endpoint="/x",
+        error_type="ValueError",
+    )
+    metrics.assert_histogram_count(
+        "meraki_span_duration_seconds",
+        2,
+        operation="op",
+        collector="C",
+        endpoint="/x",
+    )
+
+
+class _DummyTracerProvider:
+    def __init__(self) -> None:
+        self.added: list[Any] = []
+
+    def add_span_processor(self, processor: Any) -> None:
+        self.added.append(processor)
+
+
+def test_setup_span_metrics_adds_processor() -> None:
+    """``setup_span_metrics`` registers the processor with the provider."""
+
+    registry = CollectorRegistry()
+    provider = _DummyTracerProvider()
+    processor = setup_span_metrics(provider, registry)
+
+    assert isinstance(processor, SpanMetricsProcessor)
+    assert provider.added == [processor]


### PR DESCRIPTION
## Summary
- add unit tests for DNSResolver service
- add unit tests for ClientStore service
- add tests for logging helpers and decorators
- add exemplar management tests
- add span metrics processor tests

## Testing
- `make format`
- `make lint`
- `make typecheck`
- `make test`
- `make test-cov`


------
https://chatgpt.com/codex/tasks/task_e_687d27403bd08321a7ce3ffdaed0a0ec