### PR TITLE
ci(api-drift): support Claude Pro/Max OAuth token for enrichment

### DIFF
--- a/.github/actions/report-drift/action.yml
+++ b/.github/actions/report-drift/action.yml
@@ -16,7 +16,14 @@ inputs:
     description: >
       Anthropic API key. Passed explicitly (not via job env) so it is introduced only at
       this post-classification report step and never shares an environment with the fetched
-      upstream spec data. Empty => Claude enrichment is skipped.
+      upstream spec data. Empty => use the OAuth token, or skip enrichment if both are empty.
+  claude-code-oauth-token:
+    required: false
+    default: ""
+    description: >
+      Claude Pro/Max OAuth token (generate locally with `claude setup-token`). Alternative
+      to anthropic-api-key — lets enrichment run against a Claude subscription instead of
+      pay-per-use API credits. Same security boundary: introduced only at this step.
 runs:
   using: composite
   steps:
@@ -36,10 +43,11 @@ runs:
           gh issue create --label "${INPUTS_LANE_LABEL}" --title "${INPUTS_TITLE}" --body-file "${INPUTS_REPORT_PATH}"
         fi
     - name: Claude enrichment
-      if: ${{ inputs.anthropic-api-key != '' }}
+      if: ${{ inputs.anthropic-api-key != '' || inputs.claude-code-oauth-token != '' }}
       uses: anthropics/claude-code-action@eee73e2ae5399c561de4ff038aa7b36a7aa991a7 # v1.0.143
       with:
         anthropic_api_key: ${{ inputs.anthropic-api-key }}
+        claude_code_oauth_token: ${{ inputs.claude-code-oauth-token }}
         prompt: |
           A scheduled CI lane detected Cisco Meraki API drift on operations this exporter consumes.
 

--- a/.github/workflows/api-drift.yml
+++ b/.github/workflows/api-drift.yml
@@ -84,7 +84,10 @@ jobs:
           lane-label: api-drift
           title: "Meraki OpenAPI drift on consumed operations"
           report-path: /tmp/drift.md
+          # Provide EITHER: ANTHROPIC_API_KEY (pay-per-use) or CLAUDE_CODE_OAUTH_TOKEN
+          # (Claude Pro/Max subscription, via `claude setup-token`). Both empty => skip.
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude-code-oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
       - name: Resolve tracking issue on clean run
         if: steps.drift.outputs.code == '0' && steps.oasdiff.outputs.code == '0'


### PR DESCRIPTION
Lets the `api-drift` issue enrichment authenticate against a Claude Pro/Max subscription via `CLAUDE_CODE_OAUTH_TOKEN` (generated with `claude setup-token`) instead of a pay-per-use `ANTHROPIC_API_KEY`.

The `report-drift` composite action now accepts both `anthropic-api-key` and `claude-code-oauth-token`; enrichment runs if **either** is set and is skipped if both are empty. Same security boundary — the credential is only introduced at the post-classification report step, never sharing an environment with the fetched spec data.

**To enable (manual, one-time):**
1. Run `claude setup-token` locally (requires the Max subscription) → produces an OAuth token.
2. Add it as repo secret `CLAUDE_CODE_OAUTH_TOKEN`.

No code change needed to switch back to the API key later — just set `ANTHROPIC_API_KEY` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)